### PR TITLE
Updates project versions, minor build fixes

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -84,7 +84,7 @@
         </dependency>
 
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -123,6 +123,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.5.1</version>
                     <configuration>
                         <source>1.7</source>
                         <target>1.7</target>

--- a/sample-client/pom.xml
+++ b/sample-client/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.whispersystems</groupId>
             <artifactId>websocket-resources</artifactId>
-            <version>0.2.3</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
@@ -125,6 +125,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/sample-server/pom.xml
+++ b/sample-server/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>org.whispersystems</groupId>
-        <version>0.3.2</version>
+        <version>0.3.3</version>
     </parent>
 
     <name>WebSocket-Resources Sample Server Project</name>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.whispersystems</groupId>
             <artifactId>websocket-resources</artifactId>
-            <version>0.3.2</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.whispersystems</groupId>
             <artifactId>dropwizard-simpleauth</artifactId>
-            <version>0.1.0</version>
+            <version>0.1.1</version>
         </dependency>
     </dependencies>
 
@@ -125,6 +125,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixes https://github.com/WhisperSystems/WebSocket-Resources/issues/3

https://github.com/WhisperSystems/WebSocket-Resources/issues/2 will be resolved after a redeploy from the parent directory. I'm guessing the last deployment was done from the library directory to avoid deploying the sample projects so I added a deploy-plugin skip config to those for future convenience.
```
Uploading: https://oss.sonatype.org/service/local/staging/deploy/maven2/org/whispersystems/websocket-resources/0.3.3/websocket-resources-0.3.3.jar
Uploading: https://oss.sonatype.org/service/local/staging/deploy/maven2/org/whispersystems/websocket-resources/0.3.3/websocket-resources-0.3.3.pom
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Dropwizard Websocket Resources .................... SUCCESS [0.339s]
[INFO] WebSocket-Resources ............................... FAILURE [10.331s]
[INFO] WebSocket-Resources Sample Server Project ......... SKIPPED
[INFO] WebSocket-Resources Sample Client Project ......... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 10.800s
[INFO] Finished at: Sun Jul 24 18:43:16 CDT 2016
[INFO] Final Memory: 38M/981M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.4:deploy (default-deploy) on project websocket-resources: Failed to deploy artifacts: Could not transfer artifact org.whispersystems:websocket-resources:jar:0.3.3 from/to ossrh (https://oss.sonatype.org/service/local/staging/deploy/maven2/): Failed to transfer file: https://oss.sonatype.org/service/local/staging/deploy/maven2/org/whispersystems/websocket-resources/0.3.3/websocket-resources-0.3.3.jar. Return code is: 401, ReasonPhrase:Unauthorized. -> [Help 1]
```

I can also confirm that https://github.com/WhisperSystems/WebSocket-Resources/issues/1 is fixed in the latest version. `mvn clean install -D gpg.skip` completes successfully with JDK 1.8 on Windows 10.
